### PR TITLE
Attempt to fix microphone echo

### DIFF
--- a/arch/arm64/boot/dts/exynos7870-a3y17lte_common.dtsi
+++ b/arch/arm64/boot/dts/exynos7870-a3y17lte_common.dtsi
@@ -734,7 +734,7 @@
 			&audio_codec_cod3026x
 			&audio_codec_cod3026x
 			&audio_codec_cod3026x>;
-		mic-bias-mode = <1 1 2 0>;
+		mic-bias-mode = <1 0 2 0>;
 		samsung,auxdev = <&s1402x>;
 		stand-alone-fm;	/*Enable it for FM radio AP Master Mode*/
 		status = "okay";


### PR DESCRIPTION
Since Galaxy A6 doesn't have second mic and that might be causing echo in A3 and other dual mic devices ports lets change mic bias to match Galaxy A6 and test since userspace fixes didn't work so far. It needs testing since I don't have build env setup now and need my device in working condition so I can't test on it. Can be merged if it works.